### PR TITLE
Feat product over parameters

### DIFF
--- a/.codeocean/environment.json
+++ b/.codeocean/environment.json
@@ -15,8 +15,8 @@
 		"pip": {
 			"packages": [
 				{
-					"name": "git+https://github.com/AllenNeuralDynamics/aind-analysis-results.git#egg=aind-analysis-results",
-					"version": "0c929ca72ca34ca78001186f26ea6afbc7fd220e"
+					"name": "git+https://github.com/AllenNeuralDynamics/analysis-pipeline-utils#egg=aind-analysis-results",
+					"version": "ee8b95b18da98e96d2778b223cb05e41b9b65554"
 				},
 				{
 					"name": "numpy",
@@ -38,19 +38,5 @@
 			"options": {},
 			"pre_install_options": {}
 		}
-	},
-	"env_variables": [
-		{
-			"name": "DOCDB_HOST",
-			"value": "api.allenneuraldynamics-test.org"
-		},
-		{
-			"name": "DOCDB_DATABASE",
-			"value": "analysis"
-		},
-		{
-			"name": "DOCDB_COLLECTION",
-			"value": "processing_v2"
-		}
-	]
+	}
 }

--- a/.codeocean/environment.json
+++ b/.codeocean/environment.json
@@ -16,7 +16,7 @@
 			"packages": [
 				{
 					"name": "git+https://github.com/AllenNeuralDynamics/aind-analysis-results.git#egg=aind-analysis-results",
-					"version": "c64c0526d3b6ed4b8a1aa9334698a810b560607d"
+					"version": "0c929ca72ca34ca78001186f26ea6afbc7fd220e"
 				},
 				{
 					"name": "numpy",

--- a/code/job_dispatch/utils.py
+++ b/code/job_dispatch/utils.py
@@ -20,6 +20,7 @@ docdb_api_client = MetadataDbClient(
     collection=COLLECTION,
 )
 
+
 def get_data_asset_ids_from_query(query: dict):
     """
     Retrieve data asset IDs based on query passed in.
@@ -28,7 +29,7 @@ def get_data_asset_ids_from_query(query: dict):
     ----------
     query : dict
         A dictionary representing the query criteria used to filter data assets
-    
+
     Returns
     -------
     list of str
@@ -42,8 +43,9 @@ def get_data_asset_ids_from_query(query: dict):
     data_asset_ids = []
     for record in response:
         data_asset_ids.append(record["external_links"]["Code Ocean"][0])
-    
+
     return data_asset_ids
+
 
 def get_s3_input_information(
     data_asset_ids: list[str],
@@ -51,7 +53,8 @@ def get_s3_input_information(
     split_files: bool = True,
 ) -> tuple[List[str], List[str], List[Union[str, List[str]]], List[str]]:
     """
-    Returns tuple of list of s3 buckets, list of s3 asset ids, and list of s3 paths, looking for the file extension if specified
+    Returns tuple of list of s3 buckets, list of s3 asset ids,
+    and list of s3 paths, looking for the file extension if specified
 
     Parameters
     ----------
@@ -59,10 +62,13 @@ def get_s3_input_information(
         A list of data asset ids which will be used to get S3 information
 
     file_extension : str, optional
-        The file extension to filter for when searching the S3 locations. If no file extension is provided, the path to the bucket is returned from the query
+        The file extension to filter for when searching the S3 locations.
+        If no file extension is provided,
+        the path to the bucket is returned from the query
 
     split_files : bool
-        Whether or not to split files into seperate models or to store in one model as a single list.
+        Whether or not to split files into seperate models
+        or to store in one model as a single list.
 
     Returns
     -------
@@ -73,7 +79,9 @@ def get_s3_input_information(
         A list of S3 data asset ids for each S3 bucket path returned
 
     s3_paths: list of str
-        A list of either single S3 file locations (URLs) that match the query and the specified file extension or a list of S3 file locations if multiple files are returned for the file extension and split_files is False.
+        A list of either single S3 file locations (URLs) that match the query
+        and the specified file extension or a list of S3 file locations
+        if multiple files are returned for the file extension and split_files is False.
         Each location is prefixed with "s3://".
 
     s3_asset_names: list of str
@@ -91,14 +99,15 @@ def get_s3_input_information(
         projection=projection,
     )
 
-
     for record in response:
         s3_buckets.append(f"{record['location']}")
         s3_asset_ids.append(record["external_links"]["Code Ocean"][0])
         s3_asset_names.append(record["name"])
         if file_extension != "":
             file_paths = tuple(
-                s3_file_system.glob(f"{record['location']}/**/*{file_extension}")
+                s3_file_system.glob(
+                    f"{record['location']}/**/*{file_extension}"
+                )
             )
             if not file_paths:
                 raise FileNotFoundError(
@@ -110,6 +119,8 @@ def get_s3_input_information(
                     s3_paths.append(f"s3://{file}")
             else:
                 s3_paths.append([f"s3://{file}" for file in file_paths])
-            logger.info(f"Found {len(s3_paths)} *.{file_extension} files from s3")
+            logger.info(
+                f"Found {len(s3_paths)} *.{file_extension} files from s3"
+            )
 
     return s3_buckets, s3_asset_ids, s3_paths, s3_asset_names

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,4 +1,4 @@
-# hash:sha256:3cb5e058254349358cd5429be2bddb92ca57175ac66b5ed86c4628108133a50e
+# hash:sha256:642ed2ddf802d9ae002400257459a75af7dce64844efa9d57a7febd860114479
 ARG REGISTRY_HOST
 FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
@@ -20,7 +20,7 @@ RUN pip install -U --no-cache-dir \
     pandas==2.1.4 \
     pydantic-settings==2.9.1 \
     s3fs==2025.2.0 \
-    -e git+https://github.com/AllenNeuralDynamics/aind-analysis-results.git@c64c0526d3b6ed4b8a1aa9334698a810b560607d#egg=aind-analysis-results
+    -e git+https://github.com/AllenNeuralDynamics/aind-analysis-results.git@0c929ca72ca34ca78001186f26ea6afbc7fd220e#egg=aind-analysis-results
 
 COPY postInstall /
 RUN /postInstall

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -1,4 +1,4 @@
-# hash:sha256:642ed2ddf802d9ae002400257459a75af7dce64844efa9d57a7febd860114479
+# hash:sha256:43ada012d7f71699854acf7084ce47d465a484cc2db915e8db5e6885e4ef7ca2
 ARG REGISTRY_HOST
 FROM $REGISTRY_HOST/codeocean/mambaforge3:24.5.0-0-python3.12.4-ubuntu22.04
 
@@ -11,16 +11,12 @@ ARG GIT_ASKPASS
 ARG GIT_ACCESS_TOKEN
 COPY git-askpass /
 
-ENV DOCDB_HOST=api.allenneuraldynamics-test.org
-ENV DOCDB_DATABASE=analysis
-ENV DOCDB_COLLECTION=processing_v2
-
 RUN pip install -U --no-cache-dir \
     numpy==1.26.4 \
     pandas==2.1.4 \
     pydantic-settings==2.9.1 \
     s3fs==2025.2.0 \
-    -e git+https://github.com/AllenNeuralDynamics/aind-analysis-results.git@0c929ca72ca34ca78001186f26ea6afbc7fd220e#egg=aind-analysis-results
+    -e git+https://github.com/AllenNeuralDynamics/analysis-pipeline-utils@ee8b95b18da98e96d2778b223cb05e41b9b65554#egg=aind-analysis-results
 
 COPY postInstall /
 RUN /postInstall

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -1,2 +1,31 @@
 #!/usr/bin/env bash
 set -e
+
+# install updated version of code-server
+VERSION=4.100.3
+mkdir /.code-server
+cd /.code-server
+curl -fL "https://github.com/coder/code-server/releases/download/v$VERSION/code-server-$VERSION-linux-amd64.tar.gz" \
+  | tar -xz
+ln -s /.code-server/code-server-$VERSION-linux-amd64/bin/code-server  /usr/bin/code-server
+cd -
+
+
+# default behavior: extensions are installed here and reinstalled when capsule is rebuilt,
+# alternative: install extensions manually inside capsule filesystem, saved across rebuilds
+install_extensions=true
+
+if $install_extensions; then
+  mkdir -p /.vscode/extensions
+  code-server --extensions-dir=/.vscode/extensions --install-extension ms-toolsai.jupyter 
+  code-server --extensions-dir=/.vscode/extensions --install-extension ms-python.python 
+else
+  # move VS code extensions directory into capsule and symlink
+  # (this may cause issues on the first run that will be solved by reloading VS code
+  echo "mkdir -p /root/capsule/.vscode/extensions" >> /root/.profile
+  ln -s /root/capsule/.vscode /.vscode
+  # install extensions manually, or run the below lines in the terminal of cloud workstation
+#   code-server --extensions-dir=/.vscode/extensions --install-extension ms-toolsai.jupyter 
+#   code-server --extensions-dir=/.vscode/extensions --install-extension ms-python.python 
+#   code-server --extensions-dir=/.vscode/extensions --install-extension detachhead.basedpyright
+fi


### PR DESCRIPTION
Adds functionality to distribute analysis parameters over input data. Workflow currently is dispatcher expects a file called `distributed_parameters.json` such as below:

```json
[   
    {
        "analysis_name": "Unit Filtering",
        "analysis_tag": "V1",
        "isi_violations_cutoff": 0.05
    },

    {
        "analysis_name": "Unit Yield",
        "analysis_tag": "V1"
    }
]
```

Then for each input data asset, there will be a separate model for each asset x job dict. Examples of output for a model for one input asset is below

```json
{
    "s3_location": [
        "s3://codeocean-s3datasetsbucket-1u41qdg42ur9/50fa9416-4e21-482f-8901-889322a87ae3"
    ],
    "asset_id": [
        "50fa9416-4e21-482f-8901-889322a87ae3"
    ],
    "asset_name": [
        "behavior_774659_2025-06-07_14-31-15_processed_2025-06-08_03-49-49"
    ],
    "file_location": null,
    "distributed_parameters": {
        "analysis_name": "Unit Filtering",
        "analysis_tag": "V1",
        "isi_violations_cutoff": 0.05
    }
}
```

```json
{
    "s3_location": [
        "s3://codeocean-s3datasetsbucket-1u41qdg42ur9/50fa9416-4e21-482f-8901-889322a87ae3"
    ],
    "asset_id": [
        "50fa9416-4e21-482f-8901-889322a87ae3"
    ],
    "asset_name": [
        "behavior_774659_2025-06-07_14-31-15_processed_2025-06-08_03-49-49"
    ],
    "file_location": null,
    "distributed_parameters": {
        "analysis_name": "Unit Yield",
        "analysis_tag": "V1"
    }
}
```